### PR TITLE
fix: ensure `db_path` to be `Path` object

### DIFF
--- a/src/django_litestream/management/commands/litestream.py
+++ b/src/django_litestream/management/commands/litestream.py
@@ -305,7 +305,7 @@ class Command(BaseCommand):
             time.sleep(10)
 
             with tempfile.TemporaryDirectory() as temp_dir:
-                temp_db_path = Path(temp_dir) / db_path.with_suffix(".restored").name
+                temp_db_path = (Path(temp_dir) / db_path).with_suffix(".restored").name
                 result = subprocess.run(
                     [
                         app_settings.bin_path,


### PR DESCRIPTION
Hi, this PR fixes the failure of the `litestream verify` subcommand. The `db_path` can be `str` or `Path` but the code here only assumes `Path` type.

- Django version: 5.1.4
- django-litestream version: 0.3.0

`litestream.yaml`

```yaml
dbs:
- path: db.sqlite3
  replicas:
  - type: gcs
    bucket: shuuji3-litestream
    path: django-litestream-playground/db.sqlite3
```


**Error log:**

```
> ./manage.py litestream verify db.sqlite3
Traceback (most recent call last):
  File "/home/shuuji3/dev/django-litestream-playground/./manage.py", line 24, in <module>
    main()
    ~~~~^^
  File "/home/shuuji3/dev/django-litestream-playground/./manage.py", line 20, in main
    execute_from_command_line(sys.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/shuuji3/dev/django-litestream-playground/.venv/lib/python3.13/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
    ~~~~~~~~~~~~~~~^^
  File "/home/shuuji3/dev/django-litestream-playground/.venv/lib/python3.13/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/shuuji3/dev/django-litestream-playground/.venv/lib/python3.13/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shuuji3/dev/django-litestream-playground/.venv/lib/python3.13/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
  File "/home/shuuji3/dev/django-litestream-playground/.venv/lib/python3.13/site-packages/django_litestream/management/commands/litestream.py", line 206, in handle
    exit_code, msg = self.verify(_db_location_from_alias(options["db_path"]), config=options["config"])
                     ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shuuji3/dev/django-litestream-playground/.venv/lib/python3.13/site-packages/django_litestream/management/commands/litestream.py", line 308, in verify
    temp_db_path = Path(temp_dir) / db_path.with_suffix(".restored").name
                                    ^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'with_suffix'
```